### PR TITLE
Add Ender support (like Underscore.js)

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,5 +4,6 @@
 , "tags": ["base64", "encode", "decode", "base 64", "string"]
 , "version": "1.0.1"
 , "repository": { "type": "git", "url": "http://github.com/dscape/b64.git" }
+, "main": "index.js"
 , "engines": { "node": ">=v0.4.8" }
 }


### PR DESCRIPTION
See the [Underscore.js package.json](https://github.com/documentcloud/underscore/blob/master/package.json) and [this response](https://github.com/ender-js/Ender/issues/113#issuecomment-3880688) to a question about how to add Ender support to a package.
