### PR TITLE
Switch to node v4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,6 @@ language: node_js
 
 node_js:
   - 0.10
-  - 0.12
-  - iojs
+  - 4.0
 
+sudo: false

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "stream"
   ],
   "engines": {
-    "node": ">=0.10.32"
+    "node": ">=0.10.40"
   },
   "dependencies": {
     "hoek": "2.x.x"


### PR DESCRIPTION
This commit updates the minimal engine to 0.10.40 and adds node v4 as a unit testing target.